### PR TITLE
Replace deprecated `::set-output`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
-- [CI] Replace deprecated `::set-output`
 
 ## [1.0.0] - 2021-08-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [CI] Replace deprecated `::set-output`
 
 ## [1.0.0] - 2021-08-16
 ### Added

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,12 +3,12 @@
 next_version_heading=$(changelog latest --filename $2/CHANGELOG.md)
 next_version=${next_version_heading/v}
 next_version=$([[ "$next_version" == There* ]] && echo "" || echo $next_version)
-echo "::set-output name=changelog-latest-version::$next_version"
+echo "changelog-latest-version=$next_version" >> $GITHUB_OUTPUT
 
 git fetch --tags
 current_version_label=$(git describe --tags --match "$1*" --abbrev=0)
 current_version=${current_version_label/$1v/}
-echo "::set-output name=released-version::$current_version"
+echo "released-version=$current_version" >> $GITHUB_OUTPUT
 
 is_release_required=$([ $next_version == $current_version ] && echo "" || echo "true" )
-echo "::set-output name=is-release-required::$is_release_required"
+echo "is-release-required=$is_release_required" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### 🤔 What's changed?

As per the deprecation warning and explanation at https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### ⚡️ What's your motivation? 

See https://github.com/cucumber/common/issues/2150

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Is the changelog entry fine this way?

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
